### PR TITLE
fix: markdown paragraph and code text selection

### DIFF
--- a/lib/helpers/dart_syntax_highlighter.dart
+++ b/lib/helpers/dart_syntax_highlighter.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart'
     show BuildContext, Color, TextSpan, TextStyle, Theme;
-import 'package:flutter_markdown_selectionarea/flutter_markdown_selectionarea.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:highlight/highlight.dart';
 
 class DartSyntaxHighlighter extends SyntaxHighlighter {

--- a/lib/modules/design_pattern_details/widgets/rich_markdown_body.dart
+++ b/lib/modules/design_pattern_details/widgets/rich_markdown_body.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_selectionarea/flutter_markdown_selectionarea.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../../../constants/constants.dart';
 import '../../../helpers/dart_syntax_highlighter.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   faker: ^2.1.0
   flutter:
     sdk: flutter
-  flutter_markdown_selectionarea: ^0.6.14+3
+  flutter_markdown: ^0.7.3+1
   flutter_riverpod: ^2.3.6
   font_awesome_flutter: ^10.4.0
   go_router: ^7.0.1


### PR DESCRIPTION
## Before
- Multi-paragraph selection 🚫 [issue ref](https://github.com/flutter/flutter/issues/99819)
- `code` selection 🚫
![Screenshot 2023-06-21 at 16 29 13](https://github.com/mkobuolys/flutter-design-patterns/assets/59662912/7f93a6ec-e151-40a2-936c-65aca42496e5)

## After
- Multiparagraph selection ✅ 
- `code` selection ✅ 

> [Solution](https://github.com/flutter/flutter/issues/99819#issuecomment-1508694086) with support for SelectionArea

![Screenshot 2023-06-21 at 16 27 16](https://github.com/mkobuolys/flutter-design-patterns/assets/59662912/4672a7b9-5394-4b38-b033-b4a714e82916)